### PR TITLE
feat(startup): add connectivity checks for Prisma and Redis during application bootstrap

### DIFF
--- a/src/modules/infrastructure/redis/redis.service.ts
+++ b/src/modules/infrastructure/redis/redis.service.ts
@@ -156,6 +156,19 @@ export class RedisService {
   }
 
   /**
+   * Ping Redis to verify connectivity
+   * @returns PONG if connected
+   */
+  async ping(): Promise<string> {
+    try {
+      return await this.redis.ping();
+    } catch (error) {
+      this.logger.error('Failed to ping Redis', error);
+      throw error;
+    }
+  }
+
+  /**
    * Check if hash field exists
    * @param key Redis key
    * @param field Hash field


### PR DESCRIPTION
- Implemented connectivity checks for Prisma and Redis services to ensure they are reachable before starting the HTTP server.
- Added a ping method in RedisService to verify Redis connectivity.
- Enhanced error handling to log startup failures and exit the process if critical services are not available.